### PR TITLE
Support claimRefName property

### DIFF
--- a/api/v1/namespacedpv_types.go
+++ b/api/v1/namespacedpv_types.go
@@ -36,7 +36,8 @@ type NamespacedPvSpec struct {
 	Nfs              NFS                                  `json:"nfs,omitempty"`
 	Capacity         corev1.ResourceList                  `json:"capacity"`
 	// +kubebuilder:default=Filesystem
-	VolumeMode corev1.PersistentVolumeMode `json:"volumeMode,omitempty"`
+	VolumeMode   corev1.PersistentVolumeMode `json:"volumeMode,omitempty"`
+	ClaimRefName string                      `json:"claimRefName,omitempty"`
 }
 
 // NamespacedPvStatus defines the observed state of NamespacedPv

--- a/config/crd/bases/namespaced-pv.homi.run_namespacedpvs.yaml
+++ b/config/crd/bases/namespaced-pv.homi.run_namespacedpvs.yaml
@@ -48,6 +48,8 @@ spec:
                   x-kubernetes-int-or-string: true
                 description: ResourceList is a set of (resource name, quantity) pairs.
                 type: object
+              claimRefName:
+                type: string
               mountOptions:
                 type: string
               nfs:

--- a/config/samples/namespaced-pv_v1_namespacedpv.yaml
+++ b/config/samples/namespaced-pv_v1_namespacedpv.yaml
@@ -21,3 +21,4 @@ spec:
   storageClassName: nfs
   reclaimPolicy: Retain
   mountOptions: "nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2"
+  claimRefName: namespacedpv-sample-pvc

--- a/internal/controller/namespacedpv_controller.go
+++ b/internal/controller/namespacedpv_controller.go
@@ -107,19 +107,40 @@ func (r *NamespacedPvReconciler) CreateOrUpdatePv(ctx context.Context, namespace
 		"owner": namespacedPv.Name,
 	})
 	op, err := ctrl.CreateOrUpdate(ctx, r.Client, pv, func() error {
-		pv.Spec = corev1.PersistentVolumeSpec{
-			AccessModes: namespacedPv.Spec.AccessModes,
-			Capacity:    namespacedPv.Spec.Capacity,
-			PersistentVolumeSource: corev1.PersistentVolumeSource{
-				NFS: &corev1.NFSVolumeSource{
-					Server:   namespacedPv.Spec.Nfs.Server,
-					Path:     namespacedPv.Spec.Nfs.Path,
-					ReadOnly: namespacedPv.Spec.Nfs.ReadOnly,
+		if namespacedPv.Spec.ClaimRefName != "" {
+			pv.Spec = corev1.PersistentVolumeSpec{
+				AccessModes: namespacedPv.Spec.AccessModes,
+				Capacity:    namespacedPv.Spec.Capacity,
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					NFS: &corev1.NFSVolumeSource{
+						Server:   namespacedPv.Spec.Nfs.Server,
+						Path:     namespacedPv.Spec.Nfs.Path,
+						ReadOnly: namespacedPv.Spec.Nfs.ReadOnly,
+					},
 				},
-			},
-			PersistentVolumeReclaimPolicy: namespacedPv.Spec.ReclaimPolicy,
-			StorageClassName:              namespacedPv.Spec.StorageClassName,
-			VolumeMode:                    &namespacedPv.Spec.VolumeMode,
+				PersistentVolumeReclaimPolicy: namespacedPv.Spec.ReclaimPolicy,
+				StorageClassName:              namespacedPv.Spec.StorageClassName,
+				VolumeMode:                    &namespacedPv.Spec.VolumeMode,
+				ClaimRef: &corev1.ObjectReference{
+					Namespace: namespacedPv.Namespace,
+					Name:      namespacedPv.Spec.ClaimRefName,
+				},
+			}
+		} else {
+			pv.Spec = corev1.PersistentVolumeSpec{
+				AccessModes: namespacedPv.Spec.AccessModes,
+				Capacity:    namespacedPv.Spec.Capacity,
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					NFS: &corev1.NFSVolumeSource{
+						Server:   namespacedPv.Spec.Nfs.Server,
+						Path:     namespacedPv.Spec.Nfs.Path,
+						ReadOnly: namespacedPv.Spec.Nfs.ReadOnly,
+					},
+				},
+				PersistentVolumeReclaimPolicy: namespacedPv.Spec.ReclaimPolicy,
+				StorageClassName:              namespacedPv.Spec.StorageClassName,
+				VolumeMode:                    &namespacedPv.Spec.VolumeMode,
+			}
 		}
 		return nil
 	})

--- a/internal/controller/namespacedpv_controller_test.go
+++ b/internal/controller/namespacedpv_controller_test.go
@@ -127,6 +127,7 @@ func newNamespacedPv() *namespacedpvv1.NamespacedPv {
 			},
 			ReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
 			MountOptions:  "nolock,vers=4.1",
+			ClaimRefName:  "test-pvc",
 		},
 	}
 }


### PR DESCRIPTION
It supports the claimRefName property as an optional property.
claimRefName is a property that corresponds to claimRef.name of PersistentVolume. claimRef.namespace is automatically specified as the namespace where the NamespacedPV resource exists.



