### PR TITLE
Refactoring finalizer and fix status

### DIFF
--- a/api/v1/namespacedpv_types.go
+++ b/api/v1/namespacedpv_types.go
@@ -44,6 +44,8 @@ type NamespacedPvSpec struct {
 type NamespacedPvStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+	RefPvName string `json:"refPvName,omitempty"`
+	RefPvUid  string `json:"refPvUid,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/namespaced-pv.homi.run_namespacedpvs.yaml
+++ b/config/crd/bases/namespaced-pv.homi.run_namespacedpvs.yaml
@@ -89,6 +89,14 @@ spec:
             type: object
           status:
             description: NamespacedPvStatus defines the observed state of NamespacedPv
+            properties:
+              refPvName:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                type: string
+              refPvUid:
+                type: string
             type: object
         type: object
     served: true

--- a/internal/controller/namespacedpv_controller.go
+++ b/internal/controller/namespacedpv_controller.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -151,6 +152,7 @@ func (r *NamespacedPvReconciler) CreateOrUpdatePv(ctx context.Context, namespace
 
 	if op != controllerutil.OperationResultNone {
 		logger.Info("PersistentVolume created or updated", "operation", op)
+		r.UpdateStatus(ctx, namespacedPv)
 	}
 
 	return nil
@@ -187,4 +189,25 @@ func (r *NamespacedPvReconciler) DeleteNamespacedPV(ctx context.Context, namespa
 		return nil
 	}
 	return nil
+}
+
+func (r *NamespacedPvReconciler) UpdateStatus(ctx context.Context, namespacedPv *namespacedpvv1.NamespacedPv) error {
+	logger := log.FromContext(ctx)
+	namespacedPv.Status.RefPvName = namespacedPv.Spec.VolumeName + "-" + namespacedPv.Namespace
+	namespacedPv.Status.RefPvUid, _ = r.GetPvUid(ctx, namespacedPv)
+	if err := r.Status().Update(ctx, namespacedPv); err != nil {
+		logger.Error(err, "unable to update NamespacedPv status")
+		return err
+	}
+	return nil
+}
+
+func (r *NamespacedPvReconciler) GetPvUid(ctx context.Context, namespacedPv *namespacedpvv1.NamespacedPv) (string, error) {
+	logger := log.FromContext(ctx)
+	pv := &corev1.PersistentVolume{}
+	if err := r.Get(ctx, types.NamespacedName{Name: namespacedPv.Spec.VolumeName + "-" + namespacedPv.Namespace}, pv); err != nil {
+		logger.Error(err, "unable to get PersistentVolume")
+		return "", err
+	}
+	return string(pv.UID), nil
 }


### PR DESCRIPTION
Two changes were made to this PR.
- NamespacedPv.status now has the uid and name of the PV associated with it.
- Cut out the finalizer processing and removed it from the responsibility of the DeleteNamespacedPV function.