### PR TITLE
If the pv disappears, the pv will be recreated without erasing the custom resource.

### DIFF
--- a/internal/controller/namespacedpv_controller.go
+++ b/internal/controller/namespacedpv_controller.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -213,11 +212,7 @@ func (r *NamespacedPvReconciler) DeleteNamespacedPV(ctx context.Context, namespa
 					return err
 				}
 				r.Get(ctx, types.NamespacedName{Name: targetPv.Name}, targetPv)
-				cond := metav1.Preconditions{
-					UID:             &targetPv.UID,
-					ResourceVersion: &targetPv.ResourceVersion,
-				}
-				if err := r.Delete(ctx, targetPv, &client.DeleteOptions{Preconditions: &cond}); err != nil {
+				if err := r.Delete(ctx, targetPv); err != nil {
 					logger.Error(err, "unable to delete NamespacedPv")
 					return err
 				}

--- a/internal/controller/persistentvolume_controller.go
+++ b/internal/controller/persistentvolume_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"strconv"
 
 	namespacedpvv1 "github.com/homirun/namespaced-pv-controller/api/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -77,13 +78,25 @@ func (r *PersistentVolumeReconciler) DeletePV(ctx context.Context, pv *corev1.Pe
 	logger := log.FromContext(ctx)
 
 	if !pv.GetDeletionTimestamp().IsZero() {
-		if !controllerutil.ContainsFinalizer(pv, finalizerName) && pv.Annotations["pv.kubernetes.io/provisioned-by"] == "namespaced-pv-controller" {
-			controllerutil.RemoveFinalizer(pv, "namespacedpv.homi.run/pvFinalizer")
+		if controllerutil.ContainsFinalizer(pv, finalizerName) && pv.Annotations["pv.kubernetes.io/provisioned-by"] == "namespaced-pv-controller" {
+			controllerutil.RemoveFinalizer(pv, finalizerName)
+			if err := r.Update(ctx, pv); err != nil {
+				logger.Error(err, "unable to update PersistentVolume")
+				return err
+			}
+
 			logger.Info("pv finalizer is removed")
 			namespacedPv := &namespacedpvv1.NamespacedPv{}
 			r.Get(ctx, client.ObjectKey{Namespace: pv.Labels["owner-namespace"], Name: pv.Labels["owner"]}, namespacedPv)
 
-			if err := r.Delete(ctx, namespacedPv); err != nil {
+			if namespacedPv.Annotations["namespacedpv.homi.run/recreate-pv-count"] == "" {
+				namespacedPv.Annotations["namespacedpv.homi.run/recreate-pv-count"] = "0"
+			}
+
+			recreateCount, _ := strconv.Atoi(namespacedPv.Annotations["nnamespacedpv.homi.run/recreate-pv-count"])
+			// FIXME: recreateCount is always 1
+			namespacedPv.Annotations["namespacedpv.homi.run/recreate-pv-count"] = strconv.Itoa(recreateCount + 1)
+			if err := r.Update(ctx, namespacedPv); err != nil {
 				logger.Error(err, "unable to update NamespacedPv")
 				return err
 			}


### PR DESCRIPTION
Deleting a PersistentVolume will cause the PersistentVolume to be re-created without deleting the custom resource.

breaking change
ref: https://github.com/homirun/namespaced-pv-controller/pull/5